### PR TITLE
Added a check for logged in users

### DIFF
--- a/sources/public/vote.php
+++ b/sources/public/vote.php
@@ -11,7 +11,9 @@ $account = $mysqli->real_escape_string(preg_replace("/[^A-Za-z0-9 ]/", '', @$_PO
 $siteid = $mysqli->real_escape_string(@$_POST['votingsite']);
 $checkacc = $mysqli->query("SELECT * FROM accounts WHERE name = '$account'");
 $countcheckacc = $checkacc->num_rows;
+$row = $checkacc->fetch_assoc();
 if($countcheckacc == 0 && isset($_POST['submit'])) { $funct_error =  "This account doesn't exist!";}
+if($row['loggedin'] > 0 && isset($_POST['submit'])) { $funct_error =  "This account is logged in!";}
 elseif ($account == '' && isset($_POST['submit'])) {$funct_error = 'You need to put in a username!';}
 elseif(empty($_POST['votingsite']) && isset($_POST['submit'])){
 	$funct_error = "Please select a voting site";


### PR DESCRIPTION
Checks if the account's name has a value > 0 (logged in) in the database and returns an error if it is logged in and proceeds without error if it is not logged in. 

This is helpful as many servers currently cannot give vote points/rewards to users who are logged in.