### PR TITLE
Added https to Gravatar

### DIFF
--- a/assets/config/funcs.php
+++ b/assets/config/funcs.php
@@ -57,7 +57,7 @@ function redirect_wait5($url) {
 }
 
 function get_gravatar($email, $s = 80, $d = 'mm', $r = 'g', $img = false, $atts = array()) {
-    $url = 'http://www.gravatar.com/avatar/';
+    $url = 'https://www.gravatar.com/avatar/';
     $url .= md5( strtolower( trim( $email ) ) );
     $url .= "?s=$s&amp;d=identicon&amp;r=$r";
     if($img) {


### PR DESCRIPTION
Gravatar images were being served through regular http causing the "Website contains unsecure assets" when using ssl certs on your website.

This will fix that :smiley: 