### PR TITLE
Support for configuring hashing algorithm

### DIFF
--- a/assets/config/funcs.php
+++ b/assets/config/funcs.php
@@ -98,4 +98,31 @@ function getJobNames($unique) {
 	}
 	return $jobNames;
 }
+
+function hashPassword($password, $algorithm, $salt) {
+	switch (strtolower($algorithm)) {
+		case "bcrypt":
+			// Using salt has been deprecated
+			return password_hash($password, PASSWORD_BCRYPT);
+		case "sha1":
+			return sha1($password);
+		case "sha512":
+			return hash('sha512',$password.$salt);
+		
+		return sha1($password);
+	}
+}
+
+function verifyPassword($password, $hash, $algorithm, $salt) {
+	switch (strtolower($algorithm)) {
+		case "bcrypt":
+			return password_verify($password, $hash);
+		case "sha1":
+			return sha1($password) === $hash;
+		case "sha512":
+			return hash('sha512',$password.$salt) === $hash;
+		
+		return false;
+	}
+}
 ?>

--- a/assets/config/install/install.php
+++ b/assets/config/install/install.php
@@ -208,7 +208,7 @@ CREATE TABLE `".$prefix."properties` (
   `status` tinyint(1) DEFAULT NULL,
   `recaptcha_public` text DEFAULT NULL,
   `recaptcha_private` text DEFAULT NULL,
-  `hash_algorithm` varchar(45)
+  `hash_algorithm` varchar(45),
   PRIMARY KEY (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 INSERT INTO ".$prefix."properties (version, theme, nav, colnx, colvp, homecontent) VALUES (83, 'bootstrap', 1, 'paypalNX', 'votepoints', 'Admins: Click here to edit');

--- a/assets/config/install/install.php
+++ b/assets/config/install/install.php
@@ -493,11 +493,11 @@ echo "<META http-equiv=\"refresh\" content=\"0;URL=?install=4\">";
 				<div class=\"form-group\">
 					<label for=\"hashAlgorithm\">Password Hashing Algorithm</label>
 					<select name=\"hash-algorithm\" class='form-control'>
-						<option value=\"bcrypt\">BCrypt</option>
-						<option value=\"sha1\">SHA1</option>
+						<option value=\"bcrypt\">bcrypt</option>
+						<option value=\"sha1\" selected>SHA1</option>
 						<option value=\"sha512\">SHA512</option>
 					</select>
-					<small id=\"hashAlgorithmHelp\" class=\"form-text text-muted\">What algorithm should be used to hash passwords?</small>
+					<small id=\"hashAlgorithmHelp\" class=\"form-text text-muted\">What algorithm should be used to hash passwords? If you're not sure, choose SHA1.</small>
 				</div>
 				<hr/>
 					<input name='submit' type='submit' value='Submit &raquo;' class=\"btn btn-outline-primary float-right\"/>

--- a/assets/config/install/install.php
+++ b/assets/config/install/install.php
@@ -208,6 +208,7 @@ CREATE TABLE `".$prefix."properties` (
   `status` tinyint(1) DEFAULT NULL,
   `recaptcha_public` text DEFAULT NULL,
   `recaptcha_private` text DEFAULT NULL,
+  `hash_algorithm` varchar(45)
   PRIMARY KEY (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 INSERT INTO ".$prefix."properties (version, theme, nav, colnx, colvp, homecontent) VALUES (83, 'bootstrap', 1, 'paypalNX', 'votepoints', 'Admins: Click here to edit');
@@ -381,6 +382,7 @@ echo "<META http-equiv=\"refresh\" content=\"0;URL=?install=4\">";
 				$sservertype = $mysqli->real_escape_string($_POST['servertype']);
 				$scolnx = $mysqli->real_escape_string(stripslashes($_POST['colnx']));
 				$scolvp = $mysqli->real_escape_string(stripslashes($_POST['colvp']));
+				$shashalgorithm = $mysqli->real_escape_string(stripslashes($_POST['hash-algorithm']));
 				$continue = true;
 
 				if(empty($sservername)) {
@@ -420,7 +422,7 @@ echo "<META http-equiv=\"refresh\" content=\"0;URL=?install=4\">";
 				if(!$continue) {
 					echo "<hr/><button onclick=\"goBack()\" class=\"btn btn-primary\">&laquo; Go Back</button>";
 				} else {
-					$mysqli->query("UPDATE ".$prefix."properties SET name='".$sservername."', type = '".$sservertype."', client='".$sclient."', server = '".$sserver."', version='".$sversion."', forumurl='".$sforumurl."', siteurl='".$ssiteurl."', exprate='".$sexp."', mesorate='".$smeso."', droprate='".$sdrop."', gmlevel = '".$sgmlevel."', flood='1', floodint='5', theme='bootstrap', nav='1', colnx = '".$scolnx."', colvp = '".$scolvp."'");
+					$mysqli->query("UPDATE ".$prefix."properties SET name='".$sservername."', type = '".$sservertype."', client='".$sclient."', server = '".$sserver."', version='".$sversion."', forumurl='".$sforumurl."', siteurl='".$ssiteurl."', exprate='".$sexp."', mesorate='".$smeso."', droprate='".$sdrop."', gmlevel = '".$sgmlevel."', flood='1', floodint='5', theme='bootstrap', nav='1', colnx = '".$scolnx."', colvp = '".$scolvp."', hash_algorithm = '".$shashalgorithm."'");
 					echo "Working...";
 					echo "<meta http-equiv=\"refresh\" content=\"1; url=?install=5\" />";
 				}
@@ -486,6 +488,16 @@ echo "<META http-equiv=\"refresh\" content=\"0;URL=?install=4\">";
 					<label for=\"gmAccess\">GM Access</label>
 					<input name=\"gmlevel\" type=\"text\" maxlength=\"10\" class='form-control' id=\"gmAccess\" placeholder=\"3\" value=\"3\" required/>
 					<small id=\"vpColumnHelp\" class=\"form-text text-muted\">What level GM should be allowed to access the GM panel?</small>
+				</div>
+				<hr/>
+				<div class=\"form-group\">
+					<label for=\"hashAlgorithm\">Password Hashing Algorithm</label>
+					<select name=\"hash-algorithm\" class='form-control'>
+						<option value=\"bcrypt\">BCrypt</option>
+						<option value=\"sha1\">SHA1</option>
+						<option value=\"sha512\">SHA512</option>
+					</select>
+					<small id=\"hashAlgorithmHelp\" class=\"form-text text-muted\">What algorithm should be used to hash passwords?</small>
 				</div>
 				<hr/>
 					<input name='submit' type='submit' value='Submit &raquo;' class=\"btn btn-outline-primary float-right\"/>

--- a/assets/config/properties.php
+++ b/assets/config/properties.php
@@ -54,6 +54,8 @@ try {
 	/* reCAPTCHA Keys */
 	$recaptcha_public = ($prop['recaptcha_public'] ?: null);
 	$recaptcha_private = ($prop['recaptcha_private'] ?: null);
+
+	$hash_algorithm = ($prop['hash_algorithm']);
 	
 	if ($prop['nav']) {
 		$nav = "navbar navbar-expand-lg navbar-dark bg-dark";

--- a/sources/admin/properties.php
+++ b/sources/admin/properties.php
@@ -128,7 +128,7 @@ else {
 			<div class=\"form-group\">
 				<label for=\"hash-algorithm\">Password Hashing Algorithm</label>
 				<select name=\"hash-algorithm\" class='form-control'>
-					<option value=\"bcrypt\" ".($hash_algorithm === "bcrypt" ? "selected" : "").">BCrypt</option>
+					<option value=\"bcrypt\" ".($hash_algorithm === "bcrypt" ? "selected" : "").">bcrypt</option>
 					<option value=\"sha1\" ".($hash_algorithm === "sha1" ? "selected" : "").">SHA1</option>
 					<option value=\"sha512\" ".($hash_algorithm === "sha512" ? "selected" : "").">SHA512</option>
 				</select>

--- a/sources/admin/properties.php
+++ b/sources/admin/properties.php
@@ -19,6 +19,7 @@ if(isset($_POST['submit'])) {
 	$sservertype = $mysqli->real_escape_string(stripslashes($_POST['servertype']));
 	$srecaptchapublic = $mysqli->real_escape_string(stripslashes($_POST['recaptcha-public']));//can be null
 	$srecaptchaprivate = $mysqli->real_escape_string(stripslashes($_POST['recaptcha-private']));//can be null
+	$shashalgorithm = $mysqli->real_escape_string(stripslashes($_POST['hash-algorithm']));
 	$continue = true;
 
 	if(empty($sservername)) {
@@ -73,7 +74,7 @@ if(isset($_POST['submit'])) {
 		echo "<hr/><button onclick=\"goBack()\" class=\"btn btn-primary\">&laquo; Go Back</button>";
 	}
 	else {
-		$mquery = "UPDATE ".$prefix."properties SET name='$sservername', type = '$sservertype', client='$sclient', server = '$sserver', forumurl='$sforumurl', siteurl = '$ssiteurl', exprate='$sexp', mesorate='$smeso', droprate='$sdrop', version='$sversion', flood='$floodp', floodint='$floodi', gmlevel='$sgmlevel', recaptcha_public='$srecaptchapublic', recaptcha_private='$srecaptchaprivate'";
+		$mquery = "UPDATE ".$prefix."properties SET name='$sservername', type = '$sservertype', client='$sclient', server = '$sserver', forumurl='$sforumurl', siteurl = '$ssiteurl', exprate='$sexp', mesorate='$smeso', droprate='$sdrop', version='$sversion', flood='$floodp', floodint='$floodi', gmlevel='$sgmlevel', recaptcha_public='$srecaptchapublic', recaptcha_private='$srecaptchaprivate', hash_algorithm='$shashalgorithm'";
 		$exec = $mysqli->query($mquery);
 		echo "<h2 class=\"text-left\">Success</h2><hr/><div class=\"alert alert-success\">Configuration Updated</div>";
 		redirect_wait5("?base=admin&page=properties");
@@ -123,6 +124,15 @@ else {
 				<label for=\"siteURL\">Site Path <span class=\"badge badge-danger\">IMPORTANT. NEEDS TRAILING SLASH</span></label>
 				<input name=\"siteurl\" type=\"text\" maxlength=\"100\" class='form-control' id=\"siteURL\" value=\"".$siteurl."\" required/>
 				<small id=\"siteUrlHelpBlock\" class=\"form-text text-muted\">/ indicates the root directory. /base/ indicates that base has been installed in a folder called base. You <b>must</b> use a trailing slash</small>			
+			</div>
+			<div class=\"form-group\">
+				<label for=\"hash-algorithm\">Password Hashing Algorithm</label>
+				<select name=\"hash-algorithm\" class='form-control'>
+					<option value=\"bcrypt\" ".($hash_algorithm === "bcrypt" ? "selected" : "").">BCrypt</option>
+					<option value=\"sha1\" ".($hash_algorithm === "sha1" ? "selected" : "").">SHA1</option>
+					<option value=\"sha512\" ".($hash_algorithm === "sha512" ? "selected" : "").">SHA512</option>
+				</select>
+				<small id=\"hashingAlgorithmHelpBlock\" class=\"form-text text-muted\">The algorithm to be used to hash passwords for login and registration</small>			
 			</div>	
 		</div>
 		

--- a/sources/misc/login.php
+++ b/sources/misc/login.php
@@ -31,7 +31,8 @@ if(!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQU
 		$p = $_REQUEST['password'];
 		$s = $mysqli->query("SELECT * FROM `accounts` WHERE `name`='".$u."'") or die();
 		$i = $s->fetch_assoc();
-		if($i['password'] == hash('sha512',$p.$i['salt']) || sha1($p) == $i['password']) {
+		$salt = in_array('salt', $i) ? $i['salt'] : null;
+		if (verifyPassword($p, $i['password'], $hash_algorithm, $salt)) {
 			#echo "SELECT * FROM `accounts` WHERE `name`='".$i['name']."' AND `password`='".$i['password']."'";
 			$userz = $mysqli->query("SELECT * FROM `accounts` WHERE `name`='".$i['name']."' AND `password`='".$i['password']."'") or die();
 			$auser = $userz->fetch_assoc();

--- a/sources/public/register.php
+++ b/sources/public/register.php
@@ -48,9 +48,14 @@ if (isset($_POST['submit'])) {
 		}
 		echo '</div>';
 	} else {
-		$insert_user_query = "INSERT INTO accounts (`name`, `password`, `ip`, `email`, `birthday`) VALUES ('".$validated_data['username']."', '".sha1($validated_data['password'])."', '".getRealIpAddr()."', '".$validated_data['email']."', '1990-01-01')";
+		$hashed_password = hashPassword($validated_data['password'], $hash_algorithm, null);
+		$insert_user_query = "INSERT INTO accounts (`name`, `password`, `ip`, `email`, `birthday`) VALUES ('".$validated_data['username']."', '".$hashed_password."', '".getRealIpAddr()."', '".$validated_data['email']."', '1990-01-01')";
 		$mysqli->query($insert_user_query);
-		echo '<div class="alert alert-success"><b>Success!</b> Please login, and head to the downloads page to get started!</div><script>$(function() {$("#register").fadeOut();});</script>';
+		if (!empty($mysqli->error)) {
+			echo '<div class="alert alert-danger"><b>Error!</b> There was a problem registering your account.</div>';
+		} else {
+			echo '<div class="alert alert-success"><b>Success!</b> Please login, and head to the downloads page to get started!</div><script>$(function() {$("#register").fadeOut();});</script>';
+		}
 	}
 }
 ?>


### PR DESCRIPTION
Mostly this was done to support the bcrypt algorithm.

I'm not sure that salts are handled very well at the moment. We use the salt if the column exists during authentication, but we don't generate a salt when we register a new user. I haven't done this mostly because the PHP spec has deprecated the salt option for `password_hash`, and to instead use the generated salt, embedded in the hash itself. 
My thinking is we should start to move away from supporting these less secure algorithms like SHA1/512, but I've kept them in for backwards compatibility. Let me know any thoughts on this.